### PR TITLE
Make it so the .deb package says Debain/Ubuntu

### DIFF
--- a/site/themes/multimc/layouts/index.html
+++ b/site/themes/multimc/layouts/index.html
@@ -46,7 +46,7 @@
         <div class="uk-width-medium-1-3">
             <div class="uk-panel uk-panel-box">
                 <h3 class="uk-panel-title"><i class="uk-icon-linux uk-icon-small"></i> Linux</h3>
-                <a href="https://files.multimc.org/downloads/multimc_1.5-1.deb" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Debian)</a>
+                <a href="https://files.multimc.org/downloads/multimc_1.5-1.deb" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Debian/Ubuntu)</a>
                 <a href="https://aur.archlinux.org/packages/multimc-bin" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> AUR Package (Arch Linux)</a>
                 <a href="https://files.multimc.org/downloads/mmc-stable-lin32.tar.gz" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Generic 32-bit)</a>
                 <a href="https://files.multimc.org/downloads/mmc-stable-lin64.tar.gz" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Generic 64-bit)</a>

--- a/site/themes/multimc/layouts/index.html
+++ b/site/themes/multimc/layouts/index.html
@@ -46,7 +46,7 @@
         <div class="uk-width-medium-1-3">
             <div class="uk-panel uk-panel-box">
                 <h3 class="uk-panel-title"><i class="uk-icon-linux uk-icon-small"></i> Linux</h3>
-                <a href="https://files.multimc.org/downloads/multimc_1.5-1.deb" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Ubuntu)</a>
+                <a href="https://files.multimc.org/downloads/multimc_1.5-1.deb" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Debian)</a>
                 <a href="https://aur.archlinux.org/packages/multimc-bin" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> AUR Package (Arch Linux)</a>
                 <a href="https://files.multimc.org/downloads/mmc-stable-lin32.tar.gz" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Generic 32-bit)</a>
                 <a href="https://files.multimc.org/downloads/mmc-stable-lin64.tar.gz" class="uk-button uk-button-expand uk-button-success"><i class="uk-icon-download"></i> Download (Generic 64-bit)</a>


### PR DESCRIPTION
This was done because .deb is a Debian binary and Ubuntu is based on Debian