### PR TITLE
Changed Debian/Ubuntu package to work with new versions

### DIFF
--- a/site/themes/multimc/layouts/index.html
+++ b/site/themes/multimc/layouts/index.html
@@ -58,7 +58,7 @@
         <li>Arch: <tt>qt5-base</tt></li>
         <li>OpenSuse: <tt>libqt5-qtbase</tt></li>
         <li>CentOS/Fedora/RHEL: <tt>qt5-qtbase</tt></li>
-        <li>Ubuntu/Debian: <tt>qt5-default</tt></li>
+        <li>Ubuntu/Debian: <tt>qtbase5-dev, qtchooser, qt5-qmake, qtbase5-dev-tools</tt></li>
     </ul>
 
     <h2 id="DownloadDevelop">Download & Install the development version</h2>


### PR DESCRIPTION
Changed `qt5-default` to `qtbase5-dev, qtchooser, qt5-qmake, qtbase5-dev-tools` as it is identical to what `qt5-default` installed and `libqt5widgets5, libqt5gui5, libqt5network5, libqt5core5a, libqt5xml5, libqt5concurrent5` looked bad and misaligned